### PR TITLE
feat: Add macOS support with installation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,174 @@
+# Custom files
+embeddings_cache.jsonl
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# PyPI configuration file
+.pypirc

--- a/README.md
+++ b/README.md
@@ -3,17 +3,30 @@ sound-similarity sample browser via [CLAP](https://github.com/LAION-AI/CLAP) emb
 
  requires ~4.2 GB VRAM to run (you will need a GPU)
 
-### Install:
+## Install:
 
+### For Windows users:
 **download this repo, unzip it into a folder, and run `install.bat`.** you will need [CUDA](https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64) and python installed.
 
 to run after first install, run `run.bat`. it will open localhost for you
 
 code is multiplatform, but installer and run file are windows-only.
 
-other OSs: create a venv `python -m venv venv`, enter it `source venv/Scripts/activate`, run `pip install flask laion_clap librosa numpy torch`, make sure the CUDA version of torch is installed `pip install -U torch==2.4.0+cu121 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121`, then run `python sound-similarity-browser.py` and go to http://localhost:5000/
+### For Mac users:
+- Make sure Python 3.10 is installed (you can install it with homebrew)
+    - `brew install python@3.10`
+- Download this repo, unzip it into a folder
+    - `git clone https://github.com/lyramakesmusic/sample-browser`
+- Navigate to that folder in Terminal or your IDE
+- Run `chmod +x install.sh`
+- Then run `./install.sh`
 
-### Usage:
+To use after first install, run `./run.sh`
+
+### Other OSs:
+create a venv `python -m venv venv`, enter it `source venv/Scripts/activate`, run `pip install flask laion_clap librosa numpy torch`, make sure the CUDA version of torch is installed `pip install -U torch==2.4.0+cu121 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121`, then run `python sound-similarity-browser.py` and go to http://localhost:5000/
+
+## Usage:
 
 Paste a local filepath into the Cache Management input and press Process Folder. When complete, upload a sound or type a sound description and press search
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Create and activate virtual environment
+python3.10 -m venv --prompt samplebrowser venv
+source venv/bin/activate
+
+# Install base requirements
+pip install --upgrade pip setuptools wheel packaging
+pip install flask laion_clap librosa
+
+# Install PyTorch with MPS support (nightly version for best M1/M2/M3 support)
+pip install torch==2.4.0 torchvision torchaudio
+
+# Create run script
+cat > run.sh << 'EOF'
+#!/bin/bash
+source venv/bin/activate
+python3 sound-similarity-browser.py &
+PID=$!  # Capture the background process ID
+sleep 15
+open http://127.0.0.1:5000/
+# Wait for Ctrl+C
+trap "kill $PID" INT
+wait $PID
+EOF
+
+# Make run script executable
+chmod +x run.sh
+
+# Run the application
+./run.sh


### PR DESCRIPTION
# Relates to:
Resolves #1 

# Risks
Low - Changes are additive and don't modify existing functionality
- Only affects macOS installation process
- No changes to core application code

# Background

## What does this PR do?
- Adds macOS installation support via `install.sh` script
- Updates README with macOS-specific installation instructions
- Adds `.gitignore` file to exclude embeddings cache and virtual environment

## What kind of change is this?
Features (non-breaking change which adds functionality)
- Adds macOS installation support while maintaining existing Windows functionality

# Documentation changes needed?
Documentation has been updated in this PR:
- Added macOS installation instructions to README.md
- Added section specifically for Mac users with step-by-step guide

# Testing

## Where should a reviewer start?
1. Review `install.sh` script
2. Review updated README.md macOS instructions

## Detailed testing steps
On a macOS system:
1. Install Python 3.10 via homebrew
2. Clone the repository
3. Run `chmod +x install.sh`
4. Execute `./install.sh`
5. Verify the application launches and opens in browser
6. Test that the sample browser functions correctly

# Deploy Notes
New files added:
- `install.sh` - Installation script for macOS
- `.gitignore` - Standard Python gitignore with custom additions

The `install.sh` script:
- Creates a Python virtual environment
- Installs required dependencies
- Sets up PyTorch with MPS support for Apple Silicon
- Creates and configures `run.sh` for easy launching