### PR TITLE
fix: Add leading slash for audio file paths on macOS/Linux

### DIFF
--- a/sound-similarity-browser.py
+++ b/sound-similarity-browser.py
@@ -136,6 +136,12 @@ def process_folder():
 
 @app.route('/serve-audio/<path:filepath>')
 def serve_audio(filepath):
+    
+    # Check if this is a relative path on macOS or Linux
+    if os.name == 'posix':
+        # Convert to absolute path by adding the root slash
+        filepath = '/' + filepath
+    
     return send_file(filepath)
 
 @app.route('/search', methods=['POST'])


### PR DESCRIPTION
# Relates to:
Resolves #3 [bug: Cannot play matched samples in browser on macOS]

# Risks
Low. This change only affects the audio file serving route on POSIX systems (macOS/Linux).

# Background

## What does this PR do?
Fixes an issue with serving audio files on POSIX systems (macOS/Linux) by ensuring absolute paths are properly handled by prepending a forward slash when needed.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
1. Check the `/serve-audio` route in `sound-similarity-browser.py`
2. Test audio file serving on both Windows and POSIX systems

## Detailed testing steps
- Test on macOS/Linux:
  - Start the Flask application
  - Try to play an audio file through the interface
  - Verify that the audio file loads correctly with the absolute path
- Test on Windows:
  - Verify that existing functionality continues to work
  - Confirm that the POSIX-specific change doesn't affect Windows paths
